### PR TITLE
Fix release-build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          gh release create v${{ github.event.inputs.version }} --title Release v${{ github.event.inputs.version }}-alpha --notes "Java Bindings for [OTLP v${{ github.event.inputs.version }}](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v${{ github.event.inputs.version }})"
+          gh release create v${{ github.event.inputs.version }} --title "Release v${{ github.event.inputs.version }}-alpha" --notes "Java Bindings for [OTLP v${{ github.event.inputs.version }}](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v${{ github.event.inputs.version }})"


### PR DESCRIPTION
Fixes the `release-build.yml` workflow, which used to fail on the last step because the string associated with `--title` was not wrapped in quotes.