### PR TITLE
Add documenation to README.md and RELEASING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# OpenTelemetry - Protobuf messages
+# <img src="https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png" alt="OpenTelemetry Icon" width="45" height=""> Java Bindings for the OpenTelemetry Protocol (OTLP)
 
-Under Construction
+[![Maven Central](https://img.shields.io/maven-central/v/io.opentelemetry.proto/opentelemetry-proto.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22io.opentelemetry.proto%22%20AND%20a:%22opentelemetry-proto%22)
+
+Java code-generation for the OpenTelemetry Protocol Buffer data model. This repository contains
+workflows and build scripts that pull releases
+from [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) to generate and
+build Java bindings and publish them to the
+[Maven Central Repository](https://search.maven.org/artifact/io.opentelemetry.proto/opentelemetry-proto).
+
+## Published releases
+
+You can use the published releases available
+on [Maven Central](https://search.maven.org/artifact/io.opentelemetry.proto/opentelemetry-proto). To
+do so, add the following as dependencies to your build configuration and replace `{{version}}` with
+your desired version.
+
+### Maven
+
+```xml
+
+<dependency>
+  <groupId>io.opentelemetry.proto</groupId>
+  <artifactId>opentelemetry-proto</artifactId>
+  <version>{{version}}</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'io.opentelemetry.proto:opentelemetry-proto:{{version}}'
+```
+
+## Releasing
+
+See [RELEASING.md](./RELEASING.md)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ your desired version.
 
 ### Gradle
 
-```groovy
-implementation 'io.opentelemetry.proto:opentelemetry-proto:{{version}}'
+```kotlin
+implementation("io.opentelemetry.proto:opentelemetry-proto:{{version}}")
 ```
 
 ## Releasing

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,23 @@
+# Versioning and releasing
+
+Releases of the Java bindings for the OpenTelemetry Protocol (OTLP) follow the same versions
+as [releases in opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto/releases).
+
+## Starting the release
+
+Upon release of a new [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) version:
+
+- Open
+  the ["Release Build" workflow](https://github.com/open-telemetry/opentelemetry-proto-java/actions/workflows/release-build.yml)
+  in your browser
+- Click the button that says "Run workflow" next to the phrase "This workflow has a
+  `workflow_dispatch` event trigger." and then
+  - select the `main` branch
+  - enter the version of the new [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) release
+  - click "Run workflow"
+
+A successful workflow run will create:
+- a new [tag](https://github.com/open-telemetry/opentelemetry-proto-java/tags)
+- a new [release announcement](https://github.com/open-telemetry/opentelemetry-proto-java/releases)
+- a new release
+  on [Maven Central](https://search.maven.org/artifact/io.opentelemetry.proto/opentelemetry-proto)


### PR DESCRIPTION
This PR adds
- a basic repository description to `README.md` 
- a description where to find the published releases to `README.md` 
- a description of the release process to `RELEASING.md`