### PR TITLE
Seperate proto version from nebula.release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ your desired version.
 implementation("io.opentelemetry.proto:opentelemetry-proto:{{version}}")
 ```
 
+## Project setup
+
+The build downloads proto definitions
+from [open-telemetry/opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) and
+generates Java bindings:
+
+```shell
+./gradlew build
+```
+
+By default protos definitions will be downloaded for the latest published tag
+of `opentelemetry-proto-java`. For example, if the latest version
+is [0.20.0](https://github.com/open-telemetry/opentelemetry-proto-java/tree/v0.20.0), protos will be
+downloaded from
+the [v0.20.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.20.0).
+This can be overridden for the build or other gradle tasks (e.g. `publishToMavenLocal`)
+with `-Prelease.version`:
+
+```shell
+./gradlew build -Prelease.version=1.0.0
+```
+
 ## Releasing
 
 See [RELEASING.md](./RELEASING.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 }
 
 release {
+  defaultVersionStrategy = nebula.plugin.release.git.opinion.Strategies.getSNAPSHOT()
 }
 
 tasks {
@@ -24,13 +25,6 @@ tasks {
 }
 
 description = "Java Bindings for the OpenTelemetry Protocol (OTLP)"
-
-// Project version is set from -Prelease.version or inferred from the latest tag
-if (properties.contains("release.version")) {
-  version = properties.get("release.version") as String
-} else {
-  version = NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
-}
 
 val grpcVersion = "1.56.1"
 val protobufVersion = "3.23.4"
@@ -71,7 +65,14 @@ protobuf {
   }
 }
 
-val protoVersion = version
+// Proto version is set from -Prelease.version or inferred from the latest tag
+var protoVersion = if (properties.contains(
+    "release.version"
+  )) {
+  properties.get("release.version") as String
+} else {
+  NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
+}
 val protoArchive = file("$buildDir/archives/opentelemetry-proto-$protoVersion.zip")
 
 tasks {


### PR DESCRIPTION
Didn't fully fix the release on friday: https://github.com/open-telemetry/opentelemetry-proto-java/actions/runs/5627084443/job/15249055398#step:5:340

It turns out that `./gradlew build` was actually not working in this repo at all. Only releases which included `-Prelease.version` would successfully build. So all PRs builds fail, and when I fixed the PR builds, I broke the release builds. 

This should allow both to work.