### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -10,12 +10,12 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: setup-java-17
         name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,12 +10,12 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: setup-java-17
         name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,12 +12,12 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: setup-java-17
         name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,8 @@ tasks {
 
 description = "Java Bindings for the OpenTelemetry Protocol (OTLP)"
 
-val grpcVersion = "1.56.1"
-val protobufVersion = "3.23.4"
+val grpcVersion = "1.65.1"
+val protobufVersion = "4.27.2"
 
 repositories {
   mavenCentral()


### PR DESCRIPTION
Downstream projects are getting hit with protobuf updates that can't be merged. Hoping this might help.

grpc 1.56.1 -> 1.65.1
protobuf 3.23.4 -> 4.27.2

also bumped a couple of github actions.