### PR TITLE
Add build tooling to support releasing patches, i.e. 1.3.2.1

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha, or 1.2.0.1 for a patch release of the 1.2.0 proto release
         required: true
 
 jobs:
@@ -26,14 +26,14 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace
           properties: |
-            release.version=${{ github.event.inputs.version }}
+            release.version.prop=${{ github.event.inputs.version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-17.outputs.path }}
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           remote-build-cache-proxy-enabled: false
           arguments: final closeAndReleaseSonatypeStagingRepository --stacktrace
           properties: |
-            release.version=${{ github.event.inputs.version }}
+            release.version.prop=${{ github.event.inputs.version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-17.outputs.path }}
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ is [0.20.0](https://github.com/open-telemetry/opentelemetry-proto-java/tree/v0.2
 downloaded from
 the [v0.20.0 release](https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.20.0).
 This can be overridden for the build or other gradle tasks (e.g. `publishToMavenLocal`)
-with `-Prelease.version`:
+with `-Prelease.version.prop`:
 
 ```shell
-./gradlew build -Prelease.version=1.0.0
+./gradlew build -Prelease.version.prop=1.0.0
 ```
 
 ## Support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,33 @@ plugins {
   id("otel.publish-conventions")
 }
 
+// Resolve protoVersion and releaseVersion
+// If user provides property release.version.prop match against releaseVersionRegex. protoVersion is the semconv matching group (i.e. for release.version.prop=1.3.2.1, protoVersion is 1.3.2). releaseVersion is the value of the release.version.prop.
+// Else, set protoVersion and releaseVersion to the most recent git tag.
+// The releaseVersion is used to set the nebular release plugin release version. Note, the release.version.prop is used because the nebular release plugin verifies release.version matches semconv.
+// The protoVersion is used to download sources from opentelemetry-proto..
+val releaseVersionRegex = "^(?<protoversion>([0-9]*)\\.([0-9]*)\\.([0-9]*)).*\$".toRegex()
+var protoVersion = "unknown"
+var releaseVersion = "unknown"
+if (properties.contains("release.version.prop")) {
+  val releaseVersionProperty = properties.get("release.version.prop") as String
+  val matchResult = releaseVersionRegex.matchEntire(releaseVersionProperty)
+  if (matchResult == null) {
+    throw GradleException("Invalid value for release.version.prop")
+  }
+  protoVersion = matchResult.groups["protoversion"]?.value as String
+  releaseVersion = releaseVersionProperty
+} else {
+  protoVersion = NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
+  releaseVersion = protoVersion
+}
+logger.lifecycle("proto version: " + protoVersion)
+logger.lifecycle("release version: " + releaseVersion)
+
+val protoArchive = file("$buildDir/archives/opentelemetry-proto-$protoVersion.zip")
+
 release {
+  version = releaseVersion
   defaultVersionStrategy = nebula.plugin.release.git.opinion.Strategies.getSNAPSHOT()
 }
 
@@ -64,16 +90,6 @@ protobuf {
     }
   }
 }
-
-// Proto version is set from -Prelease.version or inferred from the latest tag
-var protoVersion = if (properties.contains(
-    "release.version"
-  )) {
-  properties.get("release.version") as String
-} else {
-  NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
-}
-val protoArchive = file("$buildDir/archives/opentelemetry-proto-$protoVersion.zip")
 
 tasks {
   val downloadProtoArchive by registering(Download::class) {


### PR DESCRIPTION
Build tooling to release patches when there is no corresponding release from `opentelemetry-proto`.

For example, to release a patch for `1.3.2`:
- run the [release build](https://github.com/open-telemetry/opentelemetry-proto-java/actions/workflows/release-build.yml) action
- Set the release version argument to `1.3.2.1`
- This will publish a release with version `1.3.2.1`, but which uses `opentelemetry-proto` sources from the `1.3.2` release tag

See https://github.com/open-telemetry/opentelemetry-proto-java/pull/17 for more info.