### PR TITLE
Revert PR#18

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha, or 1.2.0.1 for a patch release of the 1.2.0 proto release
+        description: The version to tag the release with, e.g., 1.2.0, 1.2.1-alpha.1
         required: true
 
 jobs:
@@ -26,14 +26,14 @@ jobs:
           remote-build-cache-proxy-enabled: false
           arguments: build --stacktrace
           properties: |
-            release.version.prop=${{ github.event.inputs.version }}
+            release.version=${{ github.event.inputs.version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-17.outputs.path }}
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           remote-build-cache-proxy-enabled: false
           arguments: final closeAndReleaseSonatypeStagingRepository --stacktrace
           properties: |
-            release.version.prop=${{ github.event.inputs.version }}
+            release.version=${{ github.event.inputs.version }}
             org.gradle.java.installations.paths=${{ steps.setup-java-17.outputs.path }}
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,32 +14,7 @@ plugins {
   id("otel.publish-conventions")
 }
 
-// Resolve protoVersion and releaseVersion
-// If user provides property release.version.prop match against releaseVersionRegex. protoVersion is the semconv matching group (i.e. for release.version.prop=1.3.2.1, protoVersion is 1.3.2). releaseVersion is the value of the release.version.prop.
-// Else, set protoVersion and releaseVersion to the most recent git tag.
-// The releaseVersion is used to set the nebular release plugin release version. Note, the release.version.prop is used because the nebula release plugin verifies release.version matches semconv.
-// The protoVersion is used to download sources from opentelemetry-proto..
-var protoVersion = "unknown"
-var releaseVersion = "unknown"
-if (properties.contains("release.version.prop")) {
-  val releaseVersionProperty = properties.get("release.version.prop") as String
-  val matchResult = "^(?<protoversion>([0-9]*)\\.([0-9]*)\\.([0-9]*)).*\$".toRegex().matchEntire(releaseVersionProperty)
-  if (matchResult == null) {
-    throw GradleException("Invalid value for release.version.prop")
-  }
-  protoVersion = matchResult.groups["protoversion"]?.value as String
-  releaseVersion = releaseVersionProperty
-} else {
-  protoVersion = NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
-  releaseVersion = protoVersion
-}
-logger.lifecycle("proto version: " + protoVersion)
-logger.lifecycle("release version: " + releaseVersion)
-
-val protoArchive = file("$buildDir/archives/opentelemetry-proto-$protoVersion.zip")
-
 release {
-  version = releaseVersion
   defaultVersionStrategy = nebula.plugin.release.git.opinion.Strategies.getSNAPSHOT()
 }
 
@@ -89,6 +64,16 @@ protobuf {
     }
   }
 }
+
+// Proto version is set from -Prelease.version or inferred from the latest tag
+var protoVersion = if (properties.contains(
+    "release.version"
+  )) {
+  properties.get("release.version") as String
+} else {
+  NearestVersionLocator(TagStrategy()).locate(release.grgit).any.toString()
+}
+val protoArchive = file("$buildDir/archives/opentelemetry-proto-$protoVersion.zip")
 
 tasks {
   val downloadProtoArchive by registering(Download::class) {


### PR DESCRIPTION
As described [here](https://github.com/open-telemetry/opentelemetry-proto-java/pull/18#issuecomment-2383906397) this didn't work.

It also added a dependency on `release.grgit` from the `nebula.release` plugin which has been removed: https://github.com/nebula-plugins/nebula-release-plugin/releases/tag/v18.0.0