### PR TITLE
Use opentelemetrybot git user for releases

### DIFF
--- a/.github/scripts/use-cla-approved-github-bot.sh
+++ b/.github/scripts/use-cla-approved-github-bot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+git config user.name opentelemetrybot
+git config user.email 107717825+opentelemetrybot@users.noreply.github.com

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           distribution: adopt
           java-version: 17
+      - name: Use CLA approved github bot
+        run: .github/scripts/use-cla-approved-github-bot.sh
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           remote-build-cache-proxy-enabled: false


### PR DESCRIPTION
To address build failure causes by change in `nebula.release` plugin: https://github.com/open-telemetry/opentelemetry-proto-java/actions/runs/11957404393/job/33334477297