### PR TITLE
Remove repo settings doc

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,6 +1,0 @@
-# Repository settings
-
-Same
-as [opentelemetry-java-instrumentation repository settings](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/.github/repository-settings.md#repository-settings),
-except that the rules for `release/*`, `v0.*`, `v1.*`, `gh-pages`, and `cloudfoundry` branches
-are not relevant in this repository.


### PR DESCRIPTION
This isn't needed anymore now that repo settings are tracked in https://github.com/open-telemetry/admin