### PR TITLE
Update CodeQL configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,9 +47,9 @@ jobs:
         uses: github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2 # v3.29.9
         with:
           languages: ${{ matrix.language }}
-          # using "latest" helps to keep up with the latest Kotlin support
+          # using "linked" helps to keep up with the latest Kotlin support
           # see https://github.com/github/codeql-action/issues/1555#issuecomment-1452228433
-          tools: latest
+          tools: linked
 
       - name: Assemble
         if: matrix.language == 'java'


### PR DESCRIPTION
CodeQL is reporting:

> `tools: latest` has been renamed to `tools: linked`, but the old name is still supported.