### PR TITLE
Use protected environment for publishing secrets

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   publish-snapshots:
+    environment: protected
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   release:
+    environment: protected
     permissions:
       contents: write # for creating the release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use the protected environment for workflow jobs that read publishing secrets.

I added the new env and secrets, will wait to remove the existing ones until after this is merged.