### PR TITLE
Populate the Develocity remote build cache

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          gradle-home-cache-excludes: >-
+            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && 'caches/build-cache-1' || '' }}
 
       - name: Publish snapshots
         run: ./gradlew assemble publishToSonatype

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
         # zizmor: ignore[cache-poisoning] This workflow builds release branches but
         # does not publish runtime artifacts.
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          gradle-home-cache-excludes: >-
+            ${{ secrets.DEVELOCITY_ACCESS_KEY != '' && github.ref_name == github.event.repository.default_branch && 'caches/build-cache-1' || '' }}
 
       - name: Build
         run: ./gradlew build

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,9 @@ plugins {
 val develocityServer = "https://develocity.opentelemetry.io"
 val isCI = System.getenv("CI") != null
 val develocityAccessKey = System.getenv("DEVELOCITY_ACCESS_KEY") ?: ""
+val isRemoteBuildCachePushEnabled = isCI && develocityAccessKey.isNotEmpty()
+val shouldDisableLocalBuildCache =
+  isRemoteBuildCachePushEnabled && System.getenv("GITHUB_REF") == "refs/heads/main"
 
 // if develocity access key is not given and we are in CI, then we publish to scans.gradle.com
 val useScansGradleCom = isCI && develocityAccessKey.isEmpty()
@@ -44,8 +47,14 @@ develocity {
 
 if (!useScansGradleCom) {
   buildCache {
+    // Tasks loaded from the local cache are never pushed to the remote cache, so authenticated
+    // main builds must execute them to populate Develocity.
+    local {
+      isEnabled = !shouldDisableLocalBuildCache
+    }
+
     remote(develocity.buildCache) {
-      isPush = isCI && develocityAccessKey.isNotEmpty()
+      isPush = isRemoteBuildCachePushEnabled
     }
   }
 }


### PR DESCRIPTION
Applies the Develocity cache fix from [opentelemetry-java-instrumentation#19533](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19533) so trusted builds populate the remote cache more effectively. [opentelemetry-java-instrumentation#19532](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/19532) is linked for context; this repository does not have the same multi-writer cache pressure.