### PR TITLE
Group minor updates with patch updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,9 +9,9 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      // group all patch and minor updates into a single weekly PR
+      "groupName": "all patch and minor versions",
+      "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["* 0-7 * * 2"] // weekly, before 8am on Tuesday
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,11 @@
 
     {
       // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       "groupName": "all patch and minor versions",
       "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["* 0-7 * * 2"] // weekly, before 8am on Tuesday
+      "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // group all GitHub Actions updates into a single weekly PR


### PR DESCRIPTION
Renovate now groups minor updates into the same weekly pull request as patch updates, instead of opening a separate pull request for each minor release as soon as it ships.

This cuts down on pull request volume noticeably. Over the last 90 days this repository saw 15 ungrouped pull requests, including five separate ones for `com.diffplug.spotless` as it went from 8.6 to 8.10. Under the new rule those five would have arrived as part of the existing weekly batch.

OpenTelemetry artifacts are excluded from the group and keep landing individually. `!io.opentelemetry**` covers the Maven coordinates we dogfood, and `!open-telemetry/**` covers GitHub releases, most importantly `open-telemetry/opentelemetry-proto`, whose cascaded releases this repository exists to track. Burying those in a weekly batch would delay the updates that matter most here.

Major updates are unaffected and still get their own pull request. GitHub Actions updates are unaffected too, since the `github actions` rule comes later and still wins for them.

This matches what `opentelemetry-java` already does.