### PR TITLE
Group minor updates with patch updates in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,9 +9,9 @@
     // ── Scheduling & grouping ──────────────────────────────────────────
 
     {
-      // group all patch updates into a single weekly PR
-      "groupName": "all patch versions",
-      "matchUpdateTypes": ["patch"],
+      // group all patch and minor updates into a single weekly PR
+      "groupName": "all patch and minor versions",
+      "matchUpdateTypes": ["patch", "minor"],
       "schedule": ["* 0-7 * * 2"] // weekly, before 8am on Tuesday
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,11 @@
 
     {
       // group all patch and minor updates into a single weekly PR
+      // (OpenTelemetry artifacts are excluded so that dogfooding and cascaded releases land individually)
       "groupName": "all patch and minor versions",
       "matchUpdateTypes": ["patch", "minor"],
-      "schedule": ["* 0-7 * * 2"] // weekly, before 8am on Tuesday
+      "schedule": ["* 0-7 * * 2"], // weekly, before 8am on Tuesday
+      "matchPackageNames": ["!io.opentelemetry**", "!open-telemetry/**"]
     },
     {
       // group all GitHub Actions updates into a single weekly PR


### PR DESCRIPTION
Renovate now groups minor updates into the same weekly pull request as patch updates, instead of opening one for every minor release the moment it ships. This repo had 15 ungrouped pull requests in the last 90 days, five of them `com.diffplug.spotless` going from 8.6 to 8.10.

OpenTelemetry updates are excluded and keep landing individually. That matters most for `open-telemetry/opentelemetry-proto` itself, whose cascaded releases this repository exists to track. Batching those would delay exactly the updates this repo cares about.

Major updates are unaffected and still get their own pull request. This matches what opentelemetry-java already does.
